### PR TITLE
Fix blockchain hash and report retrieval

### DIFF
--- a/app/services/blockchain_service.py
+++ b/app/services/blockchain_service.py
@@ -28,7 +28,10 @@ class BlockchainService:
         Generate a hash from denuncia data.
         """
         dados_concatenados = f"{denuncia_data.get('descricao')}{denuncia_data.get('categoria')}{denuncia_data.get('datetime')}"
-        if denuncia_data.get('latitude') and denuncia_data.get('longitude'):
+        if (
+            denuncia_data.get('latitude') is not None
+            and denuncia_data.get('longitude') is not None
+        ):
             dados_concatenados += f"{denuncia_data.get('latitude')}{denuncia_data.get('longitude')}"
 
         return hashlib.sha256(dados_concatenados.encode()).hexdigest()

--- a/app/strategies/polygon_provider.py
+++ b/app/strategies/polygon_provider.py
@@ -51,7 +51,7 @@ class PolygonProvider(BlockchainProvider):
 
         print(f"Total de denuncias: {total}")
 
-        START = 20
+        START = 0
 
         for i in range(START, total):
             data = self.get_report(i)


### PR DESCRIPTION
## Summary
- ensure latitude and longitude are included in hashes when they are zero
- return all blockchain reports instead of skipping first 20

## Testing
- `python -m py_compile app/services/blockchain_service.py app/strategies/polygon_provider.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684320bf0aa88321b4c1a7ba93945508